### PR TITLE
fix: gh token for releasing package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ on:
     branches:
     - main
   workflow_dispatch:
+
+permissions: 
+  contents: write
+  packages: write
+  pull-requests: write
+  issues: write
   
 name: Release
 jobs:
@@ -25,15 +31,9 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Build
         run: yarn build
-      - name: Request GitHub token
-        id: get_workflow_token
-        uses: peter-murray/workflow-application-token-action@v2.1.0
-        with:
-          application_id: ${{ secrets.APP_ID }}
-          application_private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_ACCESS_TOKEN }}
         run: yarn release


### PR DESCRIPTION
I believe GH apps don't have permissions for packages or something. Let's see if this works.